### PR TITLE
Show a basic helpful 404 page if no redirect exists.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,11 @@ ruby '2.2.0'
 gem 'puma'
 gem 'rack'
 gem 'rack-rewrite'
+gem 'rack-contrib'
 
 group :test do
   gem 'cucumber'
   gem 'rack-test'
   gem 'rspec-expectations'
+  gem 'capybara'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     builder (3.2.2)
+    capybara (2.4.4)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     cucumber (1.3.18)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -11,11 +17,17 @@ GEM
     diff-lcs (1.2.5)
     gherkin (2.12.2)
       multi_json (~> 1.3)
+    mime-types (2.4.3)
+    mini_portile (0.6.2)
     multi_json (1.10.1)
     multi_test (0.1.1)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     puma (2.11.0)
       rack (>= 1.1, < 2.0)
     rack (1.6.0)
+    rack-contrib (1.2.0)
+      rack (>= 0.9.1)
     rack-rewrite (1.5.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -23,14 +35,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.1)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  capybara
   cucumber
   puma
   rack
+  rack-contrib
   rack-rewrite
   rack-test
   rspec-expectations

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 require 'rack/rewrite'
+require 'rack/contrib/not_found'
 
 use Rack::Rewrite do
   # libxml.rubyforge.org
@@ -23,5 +24,4 @@ use Rack::Rewrite do
   # treetop.rubyforge.org
   moved_permanently %r{^/(.*)$}, 'http://cjheath.github.io/treetop/$1', host: 'treetop.rubyforge.org'
 end
-
-run -> env { [404, {}, ['Not found']] }
+run Rack::NotFound.new(File.expand_path("../public/404.html", __FILE__))

--- a/features/redirect.feature
+++ b/features/redirect.feature
@@ -29,7 +29,7 @@ Feature: Redirect old RubyForge URL
       | http://treetop.rubyforge.org/syntactic_recognition.html   | http://cjheath.github.io/treetop/syntactic_recognition.html               |
 
   Scenario:
-    When an umapped old RubyForge URL is visited
+    When an unmapped old RubyForge URL is visited
     Then a not found page should be presented
       And the page should let me search for the gem
       And the page should explain how I can fix this

--- a/features/redirect.feature
+++ b/features/redirect.feature
@@ -27,3 +27,9 @@ Feature: Redirect old RubyForge URL
       | http://rake.rubyforge.org/classes/Rake/FileList.html      | http://docs.seattlerb.org/rake/Rake/FileList.html                         |
       | http://treetop.rubyforge.org/                             | http://cjheath.github.io/treetop/                                         |
       | http://treetop.rubyforge.org/syntactic_recognition.html   | http://cjheath.github.io/treetop/syntactic_recognition.html               |
+
+  Scenario:
+    When an umapped old RubyForge URL is visited
+    Then a not found page should be presented
+      And the page should let me search for the gem
+      And the page should explain how I can fix this

--- a/features/step_definitions/redirect_steps.rb
+++ b/features/step_definitions/redirect_steps.rb
@@ -14,7 +14,7 @@ Then /^the redirect should send me to (.*)$/ do |url|
   expect(last_response.location).to eq url
 end
 
-When(/^an umapped old RubyForge URL is visited$/) do
+When(/^an unmapped old RubyForge URL is visited$/) do
   visit 'http://some-arbitrary-unmapped-gem.rubyforge.org'
 end
 

--- a/features/step_definitions/redirect_steps.rb
+++ b/features/step_definitions/redirect_steps.rb
@@ -13,3 +13,20 @@ end
 Then /^the redirect should send me to (.*)$/ do |url|
   expect(last_response.location).to eq url
 end
+
+When(/^an umapped old RubyForge URL is visited$/) do
+  visit 'http://some-arbitrary-unmapped-gem.rubyforge.org'
+end
+
+Then(/^a not found page should be presented$/) do
+  expect(Capybara.current_session.driver.response.status).to eq Rack::Utils.status_code(:not_found)
+end
+
+Then(/^the page should let me search for the gem$/) do
+  expect(page).to have_css("form[action='https://www.google.com'] input[name=q]")
+end
+
+Then(/^the page should explain how I can fix this$/) do
+  expect(page).to have_content("please submit a pull request")
+  expect(page).to have_css("a[href='https://github.com/tomstuart/rubyforge-redirects']")
+end

--- a/features/step_definitions/redirect_steps.rb
+++ b/features/step_definitions/redirect_steps.rb
@@ -19,7 +19,7 @@ When(/^an umapped old RubyForge URL is visited$/) do
 end
 
 Then(/^a not found page should be presented$/) do
-  expect(Capybara.current_session.driver.response.status).to eq Rack::Utils.status_code(:not_found)
+  expect(page.status_code).to eq Rack::Utils.status_code(:not_found)
 end
 
 Then(/^the page should let me search for the gem$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,10 +1,13 @@
 require 'rack'
 require 'rack/test'
+require 'capybara/cucumber'
 
 module App
   def app
     Rack::Builder.parse_file('config.ru').first
   end
+  extend self
 end
 
 World(Rack::Test::Methods, App)
+Capybara.app = App.app

--- a/public/404.html
+++ b/public/404.html
@@ -6,21 +6,22 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
     <script type="text/javascript">
     $(function() {
-      var term = window.location.hostname.split(".")[0];
-      $("#search-term").val(term + " ruby");
+      var project_name = window.location.hostname.split(".")[0];
+      $(".project-name").text(project_name);
+      $("#search-term").val(project_name + " ruby");
       $("#search-term").focus();
     });
     </script>
   </head>
   <body>
     <h1>Oh dear</h1>
-    <p>Sorry, RubyForge has been retired, and we don&rsquo;t know where the Foo project is hosted.</p>
+    <p>Sorry, RubyForge has been retired, and we don&rsquo;t know where the <span class="project-name"></span> project is hosted.</p>
     <p>Try this Google search instead:
       <form action="https://www.google.com">
       <input type="text" id="search-term" name="q" value="ruby" />
       <input type="submit" value="Search">
       </form>
     </p>
-    <p>If you find where this project lives now, please submit a <a href="https://github.com/tomstuart/rubyforge-redirects">pull request</a> so that future visitors can be redirected automatically.</p>
+    <p>If you find where the <span class="project-name"></span> project lives now, please submit a <a href="https://github.com/tomstuart/rubyforge-redirects">pull request</a> so that future visitors can be redirected automatically.</p>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>RubyForge has been retired</title>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <script type="text/javascript">
+    $(function() {
+      var term = window.location.hostname.split(".")[0];
+      $("#search-term").val(term + " ruby");
+      $("#search-term").focus();
+    });
+    </script>
+  </head>
+  <body>
+    <h1>Oh dear</h1>
+    <p>Sorry, RubyForge has been retired, and we don&rsquo;t know where the Foo project is hosted.</p>
+    <p>Try this Google search instead:
+      <form action="https://www.google.com">
+      <input type="text" id="search-term" name="q" value="ruby" />
+      <input type="submit" value="Search">
+      </form>
+    </p>
+    <p>If you find where this project lives now, please submit a <a href="https://github.com/tomstuart/rubyforge-redirects">pull request</a> so that future visitors can be redirected automatically.</p>
+  </body>
+</html>


### PR DESCRIPTION
This should let people search to find the gem/project they wanted, and give instruction about how to contribute a redirect if they'll like to.

This should hopefully be the very minimum to satisfy #4 , but I wouldn't expect that to be finished without some styling.
